### PR TITLE
allow specifying DL and SNS policies

### DIFF
--- a/example/sqs.tf
+++ b/example/sqs.tf
@@ -5,7 +5,7 @@ module "example_sqs" {
   team_name              = "cp"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   application            = "exampleapp"
-  
+
   # existing_user_name     = "${module.another_sqs_instance.user_name}"
 
   providers = {
@@ -22,8 +22,9 @@ resource "kubernetes_secret" "example_sqs" {
   data {
     access_key_id     = "${module.example_sqs.access_key_id}"
     secret_access_key = "${module.example_sqs.secret_access_key}"
+
     # the above will not be set if existing_user_name is defined
-    sqs_id            = "${module.example_sqs.sqs_id}"
-    sqs_arn           = "${module.example_sqs.sqs_arn}"
+    sqs_id  = "${module.example_sqs.sqs_id}"
+    sqs_arn = "${module.example_sqs.sqs_arn}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,6 @@ resource "aws_sqs_queue" "terraform_queue" {
   kms_master_key_id                 = "${var.kms_master_key_id}"
   kms_data_key_reuse_period_seconds = "${var.kms_data_key_reuse_period_seconds}"
   redrive_policy                    = "${var.redrive_policy}"
-  policy                            = "${var.policy}"
 
   tags {
     business-unit          = "${var.business-unit}"

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@ resource "aws_sqs_queue" "terraform_queue" {
   receive_wait_time_seconds         = "${var.receive_wait_time_seconds}"
   kms_master_key_id                 = "${var.kms_master_key_id}"
   kms_data_key_reuse_period_seconds = "${var.kms_data_key_reuse_period_seconds}"
+  redrive_policy                    = "${var.redrive_policy}"
+  policy                            = "${var.policy}"
 
   tags {
     business-unit          = "${var.business-unit}"

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,13 @@ variable "existing_user_name" {
   description = "if set, will add access to this queue to the existing user, otherwise a new one is created"
   default     = ""
 }
+
+variable "redrive_policy" {
+  description = "escaped JSON string to set up the Dead Letter Queue"
+  default     = ""
+}
+
+variable "policy" {
+  description = "escaped JSON string to set up access for SNS topic"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -70,8 +70,3 @@ variable "redrive_policy" {
   description = "escaped JSON string to set up the Dead Letter Queue"
   default     = ""
 }
-
-variable "policy" {
-  description = "escaped JSON string to set up access for SNS topic"
-  default     = ""
-}


### PR DESCRIPTION
**Why**
TF overwrites policies specified via the API.
This will allow teams to specify who can subscribe to a topic, and the DeadLetter fallback.
