### PR TITLE
Encrypt sqs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "example_sqs" {
 | kms_data_key_reuse_period_seconds | Seconds for which Amazon SQS can reuse a data key | integer | `0` | no |
 | existing_user_name | if set, adds a policy rather than creating a new IAM user | string | - | no |
 | redrive_policy | if set, specifies the ARN of the "DeadLetter" queue | string | - | no |
+| encrypt_sqs_kms | if set to true, it enables SSE for SQS using KMS key | string | `false` | no |
 
 ## Access policy
 

--- a/example/sqs.tf
+++ b/example/sqs.tf
@@ -1,11 +1,14 @@
 module "example_sqs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "test"
   team_name              = "cp"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   application            = "exampleapp"
   sqs_name               = "examplesqsname"
+
+  # Set encrypt_sqs_kms = "true", to enable SSE for SQS using KMS key.
+  encrypt_sqs_kms = "false"
 
   # existing_user_name     = "${module.another_sqs_instance.user_name}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,8 @@ variable "redrive_policy" {
 variable "sqs_name" {
   description = "name of the sqs queue"
 }
+
+variable "encrypt_sqs_kms" {
+  description = "If set to true, this will create aws_kms_key and aws_kms_alias resources and add kms_master_key_id in aws_sqs_queue resource"
+  default     = "false"
+}


### PR DESCRIPTION
sqs module don't have an option to opt-out encryption, this change will let users select to use encryption.

If encrypt_sqs_kms  is set to true, this will create aws_kms_key and aws_kms_alias resources, also kms_master_key_id from aws_kms_key is added to aws_sqs_queue resource.

If encrypt_sqs_kms  is set to false, the there will be no changes.

Made this change to upgrade every one to latest module as part of tfv0.12 prerequisite.