### PR TITLE
Terraform 0.12 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This Terraform module will create an AWS SQS queue and also provide the IAM cred
 
 ```hcl
 module "example_sqs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "example-env"
   team_name              = "cloud-platform"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,30 @@
 output "user_name" {
   description = "IAM user with access to the queue"
-  value       = "${join("", aws_iam_user.user.*.name)}"
+  value       = join("", aws_iam_user.user.*.name)
 }
 
 output "access_key_id" {
   description = "Access key id for the credentials"
-  value       = "${join("", aws_iam_access_key.key.*.id)}"
+  value       = join("", aws_iam_access_key.key.*.id)
 }
 
 output "secret_access_key" {
   description = "Secret for the new credentials"
-  value       = "${join("", aws_iam_access_key.key.*.secret)}"
+  value       = join("", aws_iam_access_key.key.*.secret)
 }
 
 output "sqs_id" {
   description = "The URL for the created Amazon SQS queue."
-  value       = "${aws_sqs_queue.terraform_queue.id}"
+  value       = aws_sqs_queue.terraform_queue.id
 }
 
 output "sqs_arn" {
   description = "The ARN of the SQS queue."
-  value       = "${aws_sqs_queue.terraform_queue.arn}"
+  value       = aws_sqs_queue.terraform_queue.arn
 }
 
 output "sqs_name" {
   description = "The name of the SQS queue."
-  value       = "${aws_sqs_queue.terraform_queue.name}"
+  value       = aws_sqs_queue.terraform_queue.name
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -72,5 +72,7 @@ variable "sqs_name" {
 
 variable "encrypt_sqs_kms" {
   description = "If set to true, this will create aws_kms_key and aws_kms_alias resources and add kms_master_key_id in aws_sqs_queue resource"
-  default     = "false"
+  type        = bool
+  default     = false
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR has the terraform 0.12 migration. It also includes a better way how to manage the booleans which makes the code more readable.

It was tested using the `examples/` definitions against our CP AWS Account.