### PR TITLE
Add "namespace" tag to SQS resource

### DIFF
--- a/example/sqs.tf
+++ b/example/sqs.tf
@@ -6,6 +6,7 @@ module "example_sqs" {
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   application            = "exampleapp"
   sqs_name               = "examplesqsname"
+  namespace              = var.namespace
 
   # Set encrypt_sqs_kms = "true", to enable SSE for SQS using KMS key.
   encrypt_sqs_kms = "false"

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ resource "aws_sqs_queue" "terraform_queue" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,9 @@ variable "business-unit" {
   default     = "mojdigital"
 }
 
+variable "namespace" {
+}
+
 variable "team_name" {
   description = "The name of your development team"
 }


### PR DESCRIPTION
Why:
[Tag all AWS resources with namespace name#2348](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2348)