### PR TITLE
Allow encryption of SQS messages from external accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,9 @@ resource "aws_kms_key" "kms" {
         },
         Action = [
           "kms:GenerateDataKey*",
-          "kms:Decrypt"
+          "kms:DescribeKey",
+          "kms:Decrypt",
+          "kms:Encrypt"
         ],
         Resource = "*"
       }


### PR DESCRIPTION
Previously, support was added for external accounts to read/decrypt messages.  This adds support to also send/encrypt messages to SQS queues.