### PR TITLE
Remove unused `aws_region` data call

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ No Modules.
 | [aws_iam_user_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) |
 | [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
 | [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 | [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
 | [random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) |
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {}
-
 resource "random_id" "id" {
   byte_length = 6
 }


### PR DESCRIPTION
This PR removes the unused `aws_region` data call within this module (saving an API call when the module is used).