### PR TITLE
Remove unused `aws_region` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ No Modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | application | n/a | `any` | n/a | yes |
-| aws\_region | variable into which the resource will be created | `string` | `"eu-west-2"` | no |
 | business-unit | Area of the MOJ responsible for the service. | `string` | `"mojdigital"` | no |
 | delay\_seconds | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). | `string` | `"0"` | no |
 | encrypt\_sqs\_kms | If set to true, this will create aws\_kms\_key and aws\_kms\_alias resources and add kms\_master\_key\_id in aws\_sqs\_queue resource | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -60,11 +60,6 @@ variable "kms_external_access" {
   default     = []
 }
 
-variable "aws_region" {
-  description = "variable into which the resource will be created"
-  default     = "eu-west-2"
-}
-
 variable "existing_user_name" {
   description = "if set, will add access to this queue to the existing user, otherwise a new one is created"
   default     = ""


### PR DESCRIPTION
The `aws_region` variable isn't utilised within this module, so this removes the variable declaration.