### PR TITLE
Allow TagResource and UntagResource from current account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,9 @@ resource "aws_kms_key" "kms" {
           "kms:Get*",
           "kms:Delete*",
           "kms:ScheduleKeyDeletion",
-          "kms:CancelKeyDeletion"
+          "kms:CancelKeyDeletion",
+          "kms:TagResource",
+          "kms:UntagResource"
         ],
         Resource = "*"
       },


### PR DESCRIPTION
Adds the [TagResource](https://docs.aws.amazon.com/kms/latest/APIReference/API_TagResource.html) and [UntagResource](https://docs.aws.amazon.com/kms/latest/APIReference/API_UntagResource.html) to the KMS key.