### PR TITLE
Remove access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_access_key.key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy.userpol](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_kms_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_sqs_queue.terraform_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -123,7 +119,6 @@ No modules.
 | <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). | `number` | `0` | no |
 | <a name="input_encrypt_sqs_kms"></a> [encrypt\_sqs\_kms](#input\_encrypt\_sqs\_kms) | If set to true, this will create aws\_kms\_key and aws\_kms\_alias resources and add kms\_master\_key\_id in aws\_sqs\_queue resource | `bool` | `false` | no |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | Environment name | `string` | n/a | yes |
-| <a name="input_existing_user_name"></a> [existing\_user\_name](#input\_existing\_user\_name) | if set, will add access to this queue to the existing user, otherwise a new one is created | `string` | `""` | no |
 | <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | FIFO means exactly-once processing. Duplicates are not introduced into the queue. | `bool` | `false` | no |
 | <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input\_fifo\_throughput\_limit) | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are `perQueue` (default) and `perMessageGroupId`. | `string` | `null` | no |
 | <a name="input_infrastructure_support"></a> [infrastructure\_support](#input\_infrastructure\_support) | The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>) | `string` | n/a | yes |
@@ -143,13 +138,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | Access key id for the credentials |
 | <a name="output_irsa_policy_arn"></a> [irsa\_policy\_arn](#output\_irsa\_policy\_arn) | IAM role ARN for use with IRSA |
-| <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret for the new credentials |
 | <a name="output_sqs_arn"></a> [sqs\_arn](#output\_sqs\_arn) | The ARN of the SQS queue |
 | <a name="output_sqs_id"></a> [sqs\_id](#output\_sqs\_id) | The URL for the created Amazon SQS queue |
 | <a name="output_sqs_name"></a> [sqs\_name](#output\_sqs\_name) | The name of the SQS queue |
-| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | IAM user with access to the queue |
 <!-- END_TF_DOCS -->
 
 ## Tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,3 @@
-output "user_name" {
-  description = "IAM user with access to the queue"
-  value       = join("", aws_iam_user.user.*.name)
-}
-
-output "access_key_id" {
-  description = "Access key id for the credentials"
-  value       = join("", aws_iam_access_key.key.*.id)
-  sensitive   = true
-}
-
-output "secret_access_key" {
-  description = "Secret for the new credentials"
-  value       = join("", aws_iam_access_key.key.*.secret)
-  sensitive   = true
-}
-
 output "sqs_id" {
   description = "The URL for the created Amazon SQS queue"
   value       = aws_sqs_queue.terraform_queue.id

--- a/variables.tf
+++ b/variables.tf
@@ -76,12 +76,6 @@ variable "kms_external_access" {
   default     = []
 }
 
-variable "existing_user_name" {
-  description = "if set, will add access to this queue to the existing user, otherwise a new one is created"
-  default     = ""
-  type        = string
-}
-
 variable "sqs_name" {
   description = "SQS queue name"
   type        = string


### PR DESCRIPTION
Related to [Deprecating long-lived credentials for modules](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/deprecating-long-lived-credentials.html) and ministryofjustice/cloud-platform#4546, ministryofjustice/cloud-platform#4372.